### PR TITLE
Phase 2: bump commons-logging 1.0.4 -> 1.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.0.4</version>
+            <version>1.3.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/business/converter/ColorFactory.java
+++ b/src/business/converter/ColorFactory.java
@@ -76,7 +76,8 @@ public class ColorFactory implements Serializable {
         new Color(Integer.parseInt("53C5CF", 16)), //22 Pentos
         new Color(Integer.parseInt("0F0F0F", 16)), //23 Future 1
         new Color(Integer.parseInt("0F0F0F", 16)), //24 Future 2
-        new Color(Integer.parseInt("0F0F0F", 16)) ///25 Future 3
+        new Color(Integer.parseInt("0F0F0F", 16))
+    ///25 Future 3
     };
     public static final Color[] colorBorder = {
         new Color(Integer.parseInt("FF0000", 16)), //00 unknown
@@ -104,7 +105,8 @@ public class ColorFactory implements Serializable {
         new Color(Integer.parseInt("000000", 16)), //22 Pentos
         new Color(Integer.parseInt("000000", 16)), //23 Future 1
         new Color(Integer.parseInt("000000", 16)), //24 Future 2
-        new Color(Integer.parseInt("000000", 16)) ///25 Future 3
+        new Color(Integer.parseInt("000000", 16))
+    ///25 Future 3
     };
     public static final Color[] colorBorderNew = {
         new Color(Integer.parseInt("FFFFFF", 16)), //00 unknown
@@ -132,7 +134,9 @@ public class ColorFactory implements Serializable {
         new Color(Integer.parseInt("ED1B23", 16)), //22 Pentos
         new Color(Integer.parseInt("ED1B23", 16)), //23 Future 1
         new Color(Integer.parseInt("ED1B23", 16)), //24 Future 2
-        new Color(Integer.parseInt("ED1B23", 16)) ///25 Future 3
+        new Color(Integer.parseInt("ED1B23", 16))
+
+    ///25 Future 3
     };
 
     public static Image setNacaoColor(Image image, final Color nacaoCor, final Color nacaoBorder, JPanel form) {


### PR DESCRIPTION
Upgrades commons-logging from the ancient 1.0.4 (2003) to current 1.3.4. Drop-in compatible; no API changes affecting this codebase. Part of Phase 2 library upgrade sequence.