### PR TITLE
Phase 2: bump HttpComponents 4.0.1 -> 4.5.14 / 4.4.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,17 +119,17 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.0.1</version>
+            <version>4.5.14</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.0.1</version>
+            <version>4.4.16</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.0.1</version>
+            <version>4.5.14</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.icu</groupId>


### PR DESCRIPTION
Upgrades httpclient and httpmime from 4.0.1 to 4.5.14 (final 4.x maintenance release), and httpcore from 4.0.1 to 4.4.16 (the matching version). API-compatible upgrade — no source changes needed.