### PR TITLE
Phase 2: upgrade JavaMail 1.4.7 -> 1.6.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,8 +148,8 @@
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>1.4.7</version>
+            <artifactId>jakarta.mail</artifactId>
+            <version>1.6.7</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>


### PR DESCRIPTION
Switches from the retired \com.sun.mail:javax.mail:1.4.7\ artifact to \com.sun.mail:jakarta.mail:1.6.7\ — the same library repackaged under its updated Maven coordinates after the project moved to Eclipse/Jakarta. Package names (\javax.mail.*\) are unchanged so no source edits are needed. Full Jakarta Mail 2.x migration (namespace \javax.mail\ → \jakarta.mail\) is deferred to Phase 4 alongside the Java 21 upgrade.