### PR TITLE
Phase 2: bump mysql-connector-java 8.0.17 -> 8.0.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.17</version>
+            <version>8.0.33</version>
         </dependency>
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>


### PR DESCRIPTION
Upgrades MySQL Connector/J to 8.0.33, the last release under the old \mysql:mysql-connector-java\ coordinates that maintains Java 8 compatibility. The new \com.mysql:mysql-connector-j\ artifact (8.1+) requires Java 11 — that migration is deferred to Phase 4.