### PR TITLE
Phase 2: remove unused icu4j dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,11 +131,7 @@
             <artifactId>httpmime</artifactId>
             <version>4.5.14</version>
         </dependency>
-        <dependency>
-            <groupId>com.ibm.icu</groupId>
-            <artifactId>icu4j</artifactId>
-            <version>3.6.1</version>
-        </dependency>
+
         <dependency>
             <groupId>com.itextpdf</groupId>
             <artifactId>itextpdf</artifactId>


### PR DESCRIPTION
Removes \com.ibm.icu:icu4j\ — no source file in the codebase imports it and Maven resolves it transitively from iText if needed. Confirmed green under full 10-module aggregator build.